### PR TITLE
Added ability to get JSON value as string

### DIFF
--- a/sfserialization/JSONParser.h
+++ b/sfserialization/JSONParser.h
@@ -116,8 +116,8 @@ public:
 	/// Returns error state (means invalid type)
 	bool error () const { return mType == InvalidType; }
 
-        /// Returns value as string
-        const std::string str() { return std::string(mData, mLength); }
+        /// Returns JSON source for the value as string
+        const std::string str() const { return std::string(mData, mLength); }
 
 private:
 	friend class Object;


### PR DESCRIPTION
Currently JSON parser allows to find an object by name and get it's Value. But you can't get Value's text, which may be needed sometimes (for instance, I want to desearialize one nested object, it it's found)
